### PR TITLE
fix: read cookie file

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,7 +101,7 @@ try:
     detect_update = config.get('settings','detect-update')
 
     with open("cookie.txt", "r") as cookie_file:
-        cookie = cookie_file.read()
+        cookie = cookie_file.read().strip()
 
     if cookie:
         if is_cookie_format_valid(cookie):


### PR DESCRIPTION
fix as log say
```
  File "/usr/lib/python3.13/http/client.py", line 1316, in putheader
    raise ValueError('Invalid header value %r' % (values[i],))
ValueError: Invalid header value b'_iuqxldmzr_=...\n'
```
